### PR TITLE
Major Enhancements - RX tests and RX BER for APX radios!

### DIFF
--- a/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
@@ -200,10 +200,22 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
             //Not implemented, but shouldn't raise an exception
         }
 
-        public async Task SetupExtendedRXTest()
+        public async Task SetupRXTestFMMod()
         {
             //Not implemented, but shouldn't raise an exception
         }
+
+        public async Task SetupRXTestP25BER()
+        {
+            //Not implemented, but shouldn't raise an exception
+
+        }
+
+        public async Task GenerateP25STDCal(float power)
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
     }
 }
 

--- a/OpenAutoBench-ng/Communication/Instrument/GeneralDynamics_R2670/GeneralDynamics_R2670Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/GeneralDynamics_R2670/GeneralDynamics_R2670Instrument.cs
@@ -184,7 +184,18 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
             throw new NotImplementedException();
         }
 
-        public async Task SetupExtendedRXTest()
+        public async Task SetupRXTestFMMod()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupRXTestP25BER()
+        {
+            //Not implemented, but shouldn't raise an exception
+
+        }
+
+        public async Task GenerateP25STDCal(float power)
         {
             //Not implemented, but shouldn't raise an exception
         }

--- a/OpenAutoBench-ng/Communication/Instrument/HP_8900/HP_8900Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/HP_8900/HP_8900Instrument.cs
@@ -173,9 +173,20 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
             throw new NotImplementedException("HP 8900 does not support digital tests.");
         }
 
-        public async Task SetupExtendedRXTest()
+        public async Task SetupRXTestFMMod()
         {
             //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupRXTestP25BER()
+        {
+            throw new NotImplementedException("HP 8900 does not support digital tests.");
+
+        }
+
+        public async Task GenerateP25STDCal(float power)
+        {
+            throw new NotImplementedException("HP 8900 does not support digital tests.");
         }
     }
 }

--- a/OpenAutoBench-ng/Communication/Instrument/IBaseInstrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IBaseInstrument.cs
@@ -48,6 +48,11 @@
 
         public Task SetupTXP25BERTest();
 
-        public Task SetupExtendedRXTest();
+        public Task SetupRXTestFMMod();
+
+        public Task SetupRXTestP25BER();
+
+        public Task GenerateP25STDCal(float power);
+        
     }
 }

--- a/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
@@ -188,15 +188,34 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
             await Send("Ber RESETErrors"); // Reset Error counter
         }
 
-        public async Task SetupExtendedRXTest()
+        public async Task SetupRXTestFMMod()
         {
             await Send("Generator RFOUTput 0"); // Set Generator to T/R Port
             await Send("Generator DCPOWer 1"); // Turn Generator Mode On
             await Send("Generator PTT 0"); // Sets the Generator to Off
+            await Send("Generator MOD 1"); // Sets Generator to FM Modulation
             await Send("FGen MODe3 1");  //Set Function Generator to Tone injection mode
             await Send("FGen Freq3 1000"); // 1KHz Tone Modulation
             await Send("FGen Dev3 3"); // 3kHz Deviation
             await Send("FGen SH3 0"); // Sine audio wave shape
+        }
+
+        public async Task SetupRXTestP25BER()
+        {
+            await Send("Generator RFOUTput 0"); // Set Generator to T/R Port
+            await Send("Generator DCPOWer 1"); // Turn Generator Mode On
+            await Send("Generator PTT 0"); // Sets the Generator to Off
+            await Send("FGen MODe3 0");  //Disable Funtion Generator
+            await Send("Generator MOD 8"); //Sets Generator to P25 Modulation
+            await Send("Generator P25Mode 4"); // Sets 1011HZ Std pattern
+
+        }
+
+        public async Task GenerateP25STDCal(float power)
+        {
+            await Send($"Generator RFLEVel {power.ToString()}"); //Set Generator Power level
+            await Task.Delay(1000);
+            await Send("Generator PTT 1"); //Send signal
         }
     }
 }

--- a/OpenAutoBench-ng/Communication/Instrument/Viavi_8800SX/Viavi_8800SXInstrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Viavi_8800SX/Viavi_8800SXInstrument.cs
@@ -153,7 +153,18 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
             throw new NotImplementedException();
         }
 
-        public async Task SetupExtendedRXTest()
+        public async Task SetupRXTestFMMod()
+        {
+            //Not implemented, but shouldn't raise an exception
+        }
+
+        public async Task SetupRXTestP25BER()
+        {
+            //Not implemented, but shouldn't raise an exception
+
+        }
+
+        public async Task GenerateP25STDCal(float power)
         {
             //Not implemented, but shouldn't raise an exception
         }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX.cs
@@ -50,6 +50,27 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
 
             await Task.Delay(1000);
 
+            if(testParams.doRssiTest)
+            {
+                MotorolaAPX_TestRX_RSSI test = new MotorolaAPX_TestRX_RSSI(testParams);
+                await test.setup();
+                await test.performTest();
+                await test.teardown();
+            }
+
+            await Task.Delay(1000);
+
+            if (testParams.doRxBer)
+            {
+                MotorolaAPX_TestRX_P25_BER test = new MotorolaAPX_TestRX_P25_BER(testParams);
+                await test.setup();
+                await test.performTest();
+                await test.teardown();
+
+            }
+
+            await Task.Delay(1000);
+
             if (testParams.doTxExtendedTest)
             {
                 MotorolaAPX_TestTX_ExtendedFreq test = new MotorolaAPX_TestTX_ExtendedFreq(testParams);

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestRX_P25_BER.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestRX_P25_BER.cs
@@ -1,0 +1,18 @@
+﻿using OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase;
+
+namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
+{
+    public class MotorolaAPX_TestRX_P25_BER : MotorolaXCMPRadio_TestRX_P25BER
+    {
+        public MotorolaAPX_TestRX_P25_BER(XCMPRadioTestParams testParams): base(testParams)
+        {
+        
+        }
+
+        public async Task setup()
+        {
+            await base.setup();
+            TXFrequencies = MotorolaAPX_Frequencies.TxFrequencies(Radio);
+        }
+    }
+}

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestRX_RSSI.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/APX/MotorolaAPX_TestRX_RSSI.cs
@@ -1,0 +1,18 @@
+﻿using OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase;
+
+namespace OpenAutoBench_ng.Communication.Radio.Motorola.APX
+{
+    public class MotorolaAPX_TestRX_RSSI : MotorolaXCMPRadio_TestRX_RSSI
+    {
+        public MotorolaAPX_TestRX_RSSI(XCMPRadioTestParams testParams) : base(testParams)
+        {
+
+        }
+
+        public async Task setup()
+        {
+            await base.setup();
+            TXFrequencies = MotorolaAPX_Frequencies.TxFrequencies(Radio);
+        }
+    }
+}

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_P25BER.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_P25BER.cs
@@ -1,0 +1,87 @@
+﻿using OpenAutoBench_ng.Communication.Instrument;
+using System.Reflection;
+
+namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase;
+
+public class MotorolaXCMPRadio_TestRX_P25BER : IBaseTest
+{
+    public string name
+    {
+        get
+        {
+            return " RX: P25 BER Test";
+        }
+
+    }
+
+    public bool pass { get; private set; }
+
+    public bool testCompleted { get; private set; }
+
+    protected IBaseInstrument Instrument;
+
+    protected Action<string> LogCallback;
+
+    protected MotorolaXCMPRadioBase Radio;
+
+    //private variables specific to the test
+
+    protected int[] TXFrequencies; //Technically these are "RX Frequencies for this test, but there's no harm done using the TX frequencies for testing the receiver Maybe we should rename this field to not make it TX Specific
+
+    public MotorolaXCMPRadio_TestRX_P25BER(XCMPRadioTestParams testParams)
+    {
+        LogCallback = testParams.callback;
+        Radio = testParams.radio;
+        Instrument = testParams.instrument;
+    }
+
+    public bool isRadioEligible()
+    {
+        return true;
+    }
+
+    public async Task setup()
+    {
+        LogCallback(String.Format("Setting up for {0}", name));
+        await Instrument.SetDisplay(InstrumentScreen.Generate);
+        await Task.Delay(1000);
+        await Instrument.SetupRXTestP25BER();
+        await Task.Delay(1000);
+    }
+
+    public async Task performTest()
+    {
+        try
+        {
+            for (int i= 0; i < TXFrequencies.Length; i++)
+            {
+                int currFreq = TXFrequencies[i];
+                Radio.SetReceiveConfig(XCMPRadioReceiveOption.STD_1011);
+                Radio.SetRXFrequency(currFreq, false);
+                await Instrument.SetTxFrequency(currFreq);
+                await Task.Delay(5000);
+                await Instrument.GenerateP25STDCal(-116); //For future version, this should be a customizable value
+                await Task.Delay(5000);
+                string BER = Radio.GetP25BER(4);
+                await Instrument.StopGenerating();
+                LogCallback(String.Format("Measured BER at {0}MHz: {1}", (currFreq / 1000000D), BER));
+            }
+        }
+        catch (Exception ex)
+        {
+            LogCallback(String.Format("Test failed: {0}", ex.ToString()));
+            throw new Exception("Test failed.", ex);
+        }
+    }
+
+    public async Task performAlignment()
+    {
+        //RX Test No Aligment Possble
+    }
+
+    public async Task teardown()
+    {
+        //
+    }
+
+}

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_RSSI.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_RSSI.cs
@@ -1,0 +1,87 @@
+﻿using OpenAutoBench_ng.Communication.Instrument;
+using System.Reflection;
+
+namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase;
+
+public class MotorolaXCMPRadio_TestRX_RSSI : IBaseTest
+{
+    public string name
+    {
+        get
+        {
+            return " RX: RSSI Test";
+        }
+
+    }
+
+    public bool pass { get; private set; }
+
+    public bool testCompleted { get; private set; }
+
+    protected IBaseInstrument Instrument;
+
+    protected Action<string> LogCallback;
+
+    protected MotorolaXCMPRadioBase Radio;
+
+    //private variables specific to the test
+
+    protected int[] TXFrequencies; //Technically these are "RX Frequencies for this test, but there's no harm done using the TX frequencies for testing the receiver Maybe we should rename this field to not make it TX Specific
+
+    public MotorolaXCMPRadio_TestRX_RSSI(XCMPRadioTestParams testParams)
+    {
+        LogCallback = testParams.callback;
+        Radio = testParams.radio;
+        Instrument = testParams.instrument;
+    }
+
+    public bool isRadioEligible()
+    {
+        return true;
+    }
+
+    public async Task setup()
+    {
+        LogCallback(String.Format("Setting up for {0}", name));
+        await Instrument.SetDisplay(InstrumentScreen.Generate);
+        await Task.Delay(1000);
+        await Instrument.SetupRXTestFMMod();
+        await Task.Delay(1000);
+    }
+
+    public async Task performTest()
+    {
+        try
+        {
+            for (int i = 0; i < TXFrequencies.Length; i++)
+            {
+                int currFreq = TXFrequencies[i];
+                Radio.SetReceiveConfig(XCMPRadioReceiveOption.CSQ);
+                Radio.SetRXFrequency(currFreq, false);
+                await Instrument.SetTxFrequency(currFreq);
+                await Task.Delay(5000);
+                await Instrument.GenerateSignal(-47); //For future version, this should be a customizable value
+                await Task.Delay(5000);
+                byte[] rssi = Radio.GetStatus(MotorolaXCMPRadioBase.StatusOperation.RSSI);
+                await Instrument.StopGenerating();
+                LogCallback(String.Format("Measured RSSI at {0}MHz: {1}", (currFreq / 1000000D), rssi[0]));
+            }
+        }
+        catch (Exception ex)
+        {
+            LogCallback(String.Format("Test failed: {0}", ex.ToString()));
+            throw new Exception("Test failed.", ex);
+        }
+    }
+
+    public async Task performAlignment()
+    {
+        //RX Test No Aligment Possble
+    }
+
+    public async Task teardown()
+    {
+        //
+    }
+
+}

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
@@ -61,11 +61,11 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 {
                     Radio.SetTXFrequency(TXFrequencies[i], false);
                     await Instrument.SetRxFrequency(TXFrequencies[i]);
-                    
+
                     // low power
                     Radio.Keyup();
-                    await Task.Delay(100);
-                    Radio.SoftpotUpdate(0x01, CharPoints[i*2]);
+                    await Task.Delay(500);
+                    Radio.SoftpotUpdate(0x01, CharPoints[i * 2]);
                     await Task.Delay(5000);
                     float measPow = await Instrument.MeasurePower();
                     measPow = (float)Math.Round(measPow, 2);
@@ -75,8 +75,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
 
                     // high power
                     Radio.Keyup();
-                    await Task.Delay(100);
-                    Radio.SoftpotUpdate(0x01, CharPoints[i*2+1]);
+                    await Task.Delay(500);
+                    Radio.SoftpotUpdate(0x01, CharPoints[i * 2 + 1]);
                     await Task.Delay(5000);
                     measPow = await Instrument.MeasurePower();
                     measPow = (float)Math.Round(measPow, 2);


### PR DESCRIPTION
RX tests are now fully implemented for the APX line of radios, including getting BER readings from the radio to test the receiver. Groundwork has been done to allow this to be ported over other lines of radios in the future.

While working on this, I also uncovered a timing issue that would sometime cause the application to hang while doing power tests, delays were updated to prevent this bug.

This has been fully tested with a Aeroflex ifr2975, but more work will likely be required to get other instruments going.