### PR TITLE
The R2670 is now supported!

### DIFF
--- a/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
@@ -76,7 +76,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
             await Task.Delay(500);
         }
 
-        public async Task GenerateFMSignal(float power, float afFreq)
+        public async Task GenerateFMSignal(float power, int frequency)
         {
             throw new NotImplementedException();
         }
@@ -98,7 +98,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
             throw new NotImplementedException();
         }
 
-        public async Task SetRxFrequency(int frequency)
+        public async Task SetRxFrequency(int frequency, string mode)
         {
             await Send($"SET RF:Monitor Frequency={frequency} Hz");
             // necessary to wait a little while or else it will return busy
@@ -211,7 +211,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
 
         }
 
-        public async Task GenerateP25STDCal(float power)
+        public async Task GenerateP25STDCal(float power, int frequency)
         {
             //Not implemented, but shouldn't raise an exception
         }

--- a/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Astronics_R8000/Astronics_R8000Instrument.cs
@@ -76,11 +76,6 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
             await Task.Delay(500);
         }
 
-        public async Task GenerateFMSignal(float power, int frequency)
-        {
-            throw new NotImplementedException();
-        }
-
         public async Task GenerateP251011Signal(float power)
         {
             await Send("SET P25:Gen Test Pattern=1011 Hz Tone");
@@ -98,7 +93,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
             throw new NotImplementedException();
         }
 
-        public async Task SetRxFrequency(int frequency, string mode)
+        public async Task SetRxFrequency(int frequency, testMode mode)
         {
             await Send($"SET RF:Monitor Frequency={frequency} Hz");
             // necessary to wait a little while or else it will return busy
@@ -211,7 +206,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Astronics_R8000
 
         }
 
-        public async Task GenerateP25STDCal(float power, int frequency)
+        public async Task GenerateP25STDCal(float power)
         {
             //Not implemented, but shouldn't raise an exception
         }

--- a/OpenAutoBench-ng/Communication/Instrument/Connection/SerialConnection.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Connection/SerialConnection.cs
@@ -15,8 +15,12 @@ namespace OpenAutoBench_ng.Communication.Instrument.Connection
             _serialPort.BaudRate = baudrate;
             // set 5sec timeout
             _serialPort.ReadTimeout = 5000;
-            _serialPort.NewLine = "\n";
+            _serialPort.DataBits = 8;
+            _serialPort.Parity = Parity.None;
+            _serialPort.StopBits = StopBits.One;
             _serialPort.DtrEnable = true;
+            _serialPort.RtsEnable = true;
+
         }
 
         public void Connect()

--- a/OpenAutoBench-ng/Communication/Instrument/Connection/SerialConnection.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Connection/SerialConnection.cs
@@ -18,8 +18,8 @@ namespace OpenAutoBench_ng.Communication.Instrument.Connection
             _serialPort.DataBits = 8;
             _serialPort.Parity = Parity.None;
             _serialPort.StopBits = StopBits.One;
-            _serialPort.DtrEnable = true;
-            _serialPort.RtsEnable = true;
+            _serialPort.DtrEnable = true;//this is needed for R2670
+            _serialPort.RtsEnable = true;//this is needed for R2670
 
         }
 

--- a/OpenAutoBench-ng/Communication/Instrument/GeneralDynamics_R2670/GeneralDynamics_R2670Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/GeneralDynamics_R2670/GeneralDynamics_R2670Instrument.cs
@@ -1,4 +1,5 @@
 ﻿using OpenAutoBench_ng.Communication.Instrument.Connection;
+using System.Globalization;
 
 namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 {
@@ -8,7 +9,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         public bool Connected { get; private set; }
 
-        public bool SupportsP25 { get { return false; } }
+        public bool SupportsP25 { get { return true; } }
 
         public bool SupportsDMR { get { return false; } }
 
@@ -16,6 +17,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
         {
             Connected = false;
             Connection = conn;
+
         }
 
         public async Task Connect()
@@ -33,15 +35,19 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
             throw new NotImplementedException();
         }
 
-        public async Task GenerateFMSignal(float power, float afFreq)
+        public async Task GenerateFMSignal(float power, int frequency)
         {
-            //GenerateSignal(power);
-            throw new NotImplementedException();
+            string freq = (frequency / 1_000_000.0).ToString("F5");
+            string pwr = power.ToString("F1");
+            string str = "RG "+ freq+ ", 1, " + pwr + ", 1, 1\r";
+            await Transmit(str);
         }
 
-        public Task StopGenerating()
-        { 
-            throw new NotImplementedException();
+        public async Task StopGenerating()
+        {
+            // The R2670 continuously transmit in generate mode. To stop generating, we go bact to monitor mode.
+            await Transmit($"ARM 140.00000 1, 1, 1\r");
+            await Transmit("RM 140.00000, 1, 1, 1, 1\r"); 
         }
 
         public async Task SetGenPort(InstrumentOutputPort outputPort)
@@ -51,42 +57,78 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         public async Task SetRxFrequency(int frequency)
         {
-            // RM command
-            throw new NotImplementedException();
+            string freq = (frequency / 1_000_000.0).ToString("F5");
+            await Transmit($"RM {freq} 1, 1, 1, 1\r");
+        }
+
+        public async Task SetRxFrequency(int frequency, string mode)
+        {
+
+            if (mode == "ANALOG")
+            {
+                string freq = (frequency / 1_000_000.0).ToString("F5");
+                await Transmit($"RM {freq} 1, 1, 1, 1\r");
+            }
+            else if (mode == "P25")
+            {
+                string freq = (frequency / 1_000_000.0).ToString("F5");
+                await Transmit($"ARM {freq} 1, 1, 1\r");
+            }
+            else if (mode == "DMR")
+            {
+                throw new NotImplementedException("R2670 does not support DMR.");
+            }
         }
 
         public async Task SetTxFrequency(int frequency)
         {
-            throw new NotImplementedException();
+            string freq = (frequency / 1_000_000.0).ToString("F5");
+            await Transmit("");
         }
 
         public async Task<float> MeasurePower()
         {
-            // MR command, pg. 106
-            await Transmit("MR 0");
-            string[] results = await ReadMRReadings();
-            return float.Parse(results[1]);
+
+            await Transmit("MR 0;?2\r");
+            string[] results = await GetReadings(1);
+
+            float powerWatts = float.Parse(results[0].Split(',')[1].Replace("W", "").Trim(),
+                                           NumberStyles.Float,
+                                           CultureInfo.InvariantCulture);
+            return powerWatts;
         }
 
         public async Task<float> MeasureFrequencyError()
         {
             // MR command, pg. 106
-            await Transmit("MR 0");
-            string[] results = await ReadMRReadings();
-            return float.Parse(results[0]);
+            await Transmit("MR 0;?1\r");
+            string[] results = await GetReadings(1);
+
+            float frequencyErrorHz = float.Parse(results[0].Split(',')[1].Replace("kHz", "").Trim(), NumberStyles.Float, CultureInfo.InvariantCulture) * 1000;
+            return frequencyErrorHz;
         }
 
         public async Task<float> MeasureFMDeviation()
         {
             // MR command, pg. 106
-            await Transmit("MR 0");
-            string[] results = await ReadMRReadings();
-            return float.Parse(results[1]);
+            await Transmit("MR 0;?\r");
+            string[] results = await GetReadings(4);
+            float fmDeviationPosHz = float.Parse(results[2].Replace("MM+,", "").Replace("kHz", "").Trim(),
+                                          NumberStyles.Float,
+                                          CultureInfo.InvariantCulture) * 1000;
+
+            float fmDeviationNegHz = float.Parse(results[3].Replace("MM-,", "").Replace("kHz", "").Trim(),
+                                          NumberStyles.Float,
+                                          CultureInfo.InvariantCulture) * 1000;
+
+            float deviation = (Math.Abs(fmDeviationPosHz) + Math.Abs(fmDeviationNegHz)) / 2;
+            return deviation;
         }
 
         public async Task<string> GetInfo()
         {
             return await Send("*IDN?");
+
         }
 
         public async Task Reset()
@@ -96,17 +138,17 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         public async Task SetDisplay(InstrumentScreen screen)
         {
-            throw new NotImplementedException();
+            //throw new NotImplementedException();
         }
 
-        public Task<float> MeasureP25RxBer()
+        public async Task<float> MeasureP25RxBer()
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("The R2670 does not have a command to get the BER remotely. This test is not available with this instrument");
         }
 
         public Task<float> MeasurDMRRxBer()
         {
-            throw new NotImplementedException("R2670 does not support DMR.");
+            throw new NotImplementedException("The R2670 does not support DMR.");
         }
 
         public Task<float> MeasureDMRRxBer()
@@ -114,9 +156,9 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
             throw new NotImplementedException();
         }
 
-        public Task ResetBERErrors()
+        public async Task ResetBERErrors()
         {
-            throw new NotImplementedException();
+           // throw new NotImplementedException();
         }
 
         /**
@@ -158,6 +200,21 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
             }
             return valList.ToArray();
         }
+        /// <summary>
+        /// Parse the arguments from a querry command that returns multiple values. The number of expected values is provided as an argument
+        /// </summary>
+        /// <param name="nbrValues"></param>
+        /// <returns></returns>
+        private async Task<string[]> GetReadings(int nbrValues)
+        {
+            List<string> values = new List<string>();
+            for (int i=0; i<nbrValues; i++)
+            {
+                string val = await ReadLine();
+                values.Add(val);
+            }
+            return  values.ToArray();
+        }
 
         public async Task SetupRefOscillatorTest_P25()
         {
@@ -166,39 +223,76 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         public async Task SetupRefOscillatorTest_FM()
         {
-            //Not implemented, but shouldn't raise an exception
+            await Transmit("MODE 0\r"); // Standard mode
+            await Transmit("RM 136.00000, 1, 1, 1, 0\r"); // Monitor, 20db attenuation, RF Port, FM, Wideband // The frequency is not relevant it will be adjusted during test sequence
+
         }
 
         public async Task SetupTXPowerTest()
         {
-            //Not implemented, but shouldn't raise an exception
+            await Transmit("MODE 0\r"); // Standard mode
+            await Transmit("RM 137.00000, 1, 1, 1, 0\r"); // Monitor, 20db attenuation, RF Port, FM, Wideband // The frequency is not relevant it will be adjusted during test sequence
         }
 
         public async Task SetupTXDeviationTest()
         {
-            //Not implemented, but shouldn't raise an exception
+            await Transmit("MODE 0\r"); // Standard mode
+            await Transmit("RM 138.00000, 1, 1, 1, 1\r"); // Monitor, 20db attenuation, RF Port, FM, Wideband // The frequency is not relevant it will be adjusted during test sequence
+            await Transmit("FF 0, 2\r");
         }
 
         public async Task SetupTXP25BERTest()
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException("The R2670 does not have a command to get the BER remotely. This test is not available");
         }
 
         public async Task SetupRXTestFMMod()
         {
-            //Not implemented, but shouldn't raise an exception
+            await Transmit("MODE 0\r"); // Standard mode
+            await Transmit("RM 139.00000, 1, 1, 1, 1\r"); // Monitor, 20db attenuation, RF Port, FM, Narrowband // The frequency is not relevant it will be adjusted during test sequence
         }
 
         public async Task SetupRXTestP25BER()
         {
-            //Not implemented, but shouldn't raise an exception
+            await Transmit("MODE 5\r");
+            await Task.Delay(3000);
+            await Transmit("ARG 141.00000, 1, -120.0, 1\r");
+            await Task.Delay(3000);
+
+            //There is no way to change the P25 Audio Generation features programatically, so keypress must be manially registered to configure this test
+            //For this to work, the cursor in the P25 Audio Zone must be in the default spot
+
+            await Transmit("GK 3, 2\r"); //AUD key press
+            await Task.Delay(200);
+            await Transmit("GK 2, 2\r"); // SK3 Key Press - This sets the code to 1011HZ Pattern
+            await Task.Delay(200);
+            await Transmit("GK 4, 0\r"); // Up Key Press
+            await Task.Delay(200);
+            await Transmit("GK 0, 2\r"); // 2 Key press
+            await Task.Delay(200);
+            await Transmit("GK 1, 1\r"); // 8 Key press
+            await Task.Delay(200);
+            await Transmit("GK 0, 3\r"); // 3 Key press
+            await Task.Delay(200);
+            await Transmit("GK 4, 4\r"); // TAB Key Press
+            await Task.Delay(200);
+            await Transmit("GK 2, 0"); // SK1 Key Press - Set P25 Transmit to continuous
+            await Task.Delay(200);
+            await Transmit("GK 4, 1"); // Down Key Press
+            await Task.Delay(200);
 
         }
 
-        public async Task GenerateP25STDCal(float power)
+        public async Task GenerateP25STDCal(float power, int frequency)
         {
-            //Not implemented, but shouldn't raise an exception
+            await Transmit("mode 5\r");
+            string freq = (frequency / 1_000_000.0).ToString("F5");
+            string pwr = power.ToString("F1");
+            string str = "ARG " + freq + ", 1, " + pwr + ", 1\r";
+            await Transmit(str);
+            await Task.Delay(1000);
         }
     }
+    
 }
 

--- a/OpenAutoBench-ng/Communication/Instrument/GeneralDynamics_R2670/GeneralDynamics_R2670Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/GeneralDynamics_R2670/GeneralDynamics_R2670Instrument.cs
@@ -13,6 +13,8 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         public bool SupportsDMR { get { return false; } }
 
+        private int txFreq;
+
         public GeneralDynamics_R2670Instrument(IInstrumentConnection conn, int addr)
         {
             Connected = false;
@@ -32,16 +34,19 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         public async Task GenerateSignal(float power)
         {
-            throw new NotImplementedException();
+            string freq = (txFreq / 1_000_000.0).ToString("F5");
+            string pwr = power.ToString("F1");
+            string str = "RG " + freq + ", 1, " + pwr + ", 1, 1\r";
+            await Transmit(str);
         }
 
-        public async Task GenerateFMSignal(float power, int frequency)
+       /* public async Task GenerateFMSignal(float power, int frequency)
         {
             string freq = (frequency / 1_000_000.0).ToString("F5");
             string pwr = power.ToString("F1");
             string str = "RG "+ freq+ ", 1, " + pwr + ", 1, 1\r";
             await Transmit(str);
-        }
+        } */
 
         public async Task StopGenerating()
         {
@@ -57,24 +62,23 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         public async Task SetRxFrequency(int frequency)
         {
-            string freq = (frequency / 1_000_000.0).ToString("F5");
-            await Transmit($"RM {freq} 1, 1, 1, 1\r");
+            
         }
 
-        public async Task SetRxFrequency(int frequency, string mode)
+        public async Task SetRxFrequency(int frequency, testMode mode)
         {
 
-            if (mode == "ANALOG")
+            if (mode == testMode.ANALOG)
             {
                 string freq = (frequency / 1_000_000.0).ToString("F5");
                 await Transmit($"RM {freq} 1, 1, 1, 1\r");
             }
-            else if (mode == "P25")
+            else if (mode == testMode.P25)
             {
                 string freq = (frequency / 1_000_000.0).ToString("F5");
                 await Transmit($"ARM {freq} 1, 1, 1\r");
             }
-            else if (mode == "DMR")
+            else if (mode == testMode.DMR)
             {
                 throw new NotImplementedException("R2670 does not support DMR.");
             }
@@ -82,8 +86,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         public async Task SetTxFrequency(int frequency)
         {
-            string freq = (frequency / 1_000_000.0).ToString("F5");
-            await Transmit("");
+            txFreq = frequency;
         }
 
         public async Task<float> MeasurePower()
@@ -283,10 +286,10 @@ namespace OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670
 
         }
 
-        public async Task GenerateP25STDCal(float power, int frequency)
+        public async Task GenerateP25STDCal(float power)
         {
             await Transmit("mode 5\r");
-            string freq = (frequency / 1_000_000.0).ToString("F5");
+            string freq = (txFreq / 1_000_000.0).ToString("F5");
             string pwr = power.ToString("F1");
             string str = "ARG " + freq + ", 1, " + pwr + ", 1\r";
             await Transmit(str);

--- a/OpenAutoBench-ng/Communication/Instrument/HP_8900/HP_8900Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/HP_8900/HP_8900Instrument.cs
@@ -51,10 +51,10 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
             await Send("RFG:AMPL " + power.ToString());
         }
 
-        public async Task GenerateFMSignal(float power, float afFreq)
+        public async Task GenerateFMSignal(float power, int frequency)
         {
-            await GenerateSignal(power);
-            throw new NotImplementedException();
+            await Send("RFG:FREQ " + frequency.ToString());
+            await Send("RFG:AMPL " + power.ToString());
         }
 
         public async Task StopGenerating()
@@ -76,9 +76,20 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
             }
         }
 
-        public async Task SetRxFrequency(int frequency)
+        public async Task SetRxFrequency(int frequency, string mode)
         {
-            await Transmit(string.Format("RFAN:FREQ {0}", frequency.ToString()));
+            if (mode == "ANALOG")
+            {
+                await Transmit(string.Format("RFAN:FREQ {0}", frequency.ToString()));
+            }
+            else if (mode == "P25")
+            {
+                throw new NotImplementedException("HP 8900 does not support digital tests.");
+            }
+            else if (mode =="DMR")
+            {
+                throw new NotImplementedException("HP 8900 does not support digital tests.");
+            }
         }
 
         public async Task SetTxFrequency(int frequency)
@@ -184,7 +195,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
 
         }
 
-        public async Task GenerateP25STDCal(float power)
+        public async Task GenerateP25STDCal(float power, int frequency)
         {
             throw new NotImplementedException("HP 8900 does not support digital tests.");
         }

--- a/OpenAutoBench-ng/Communication/Instrument/HP_8900/HP_8900Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/HP_8900/HP_8900Instrument.cs
@@ -51,9 +51,8 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
             await Send("RFG:AMPL " + power.ToString());
         }
 
-        public async Task GenerateFMSignal(float power, int frequency)
+        public async Task GenerateFMSignal(float power)
         {
-            await Send("RFG:FREQ " + frequency.ToString());
             await Send("RFG:AMPL " + power.ToString());
         }
 
@@ -76,17 +75,17 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
             }
         }
 
-        public async Task SetRxFrequency(int frequency, string mode)
+        public async Task SetRxFrequency(int frequency, testMode mode)
         {
-            if (mode == "ANALOG")
+            if (mode == testMode.ANALOG)
             {
                 await Transmit(string.Format("RFAN:FREQ {0}", frequency.ToString()));
             }
-            else if (mode == "P25")
+            else if (mode == testMode.P25)
             {
                 throw new NotImplementedException("HP 8900 does not support digital tests.");
             }
-            else if (mode =="DMR")
+            else if (mode == testMode.DMR)
             {
                 throw new NotImplementedException("HP 8900 does not support digital tests.");
             }
@@ -195,7 +194,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.HP_8900
 
         }
 
-        public async Task GenerateP25STDCal(float power, int frequency)
+        public async Task GenerateP25STDCal(float power)
         {
             throw new NotImplementedException("HP 8900 does not support digital tests.");
         }

--- a/OpenAutoBench-ng/Communication/Instrument/IBaseInstrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IBaseInstrument.cs
@@ -1,5 +1,12 @@
 ﻿namespace OpenAutoBench_ng.Communication.Instrument
 {
+    public enum testMode
+    {
+        ANALOG = 0x00,
+        P25 = 0x01,
+        DMR = 0x02,
+    }
+    
     public interface IBaseInstrument
     {
         public bool Connected { get; }
@@ -10,13 +17,12 @@
         public Task Connect();
         public Task Disconnect();
         public Task GenerateSignal(float power);
-        public Task GenerateFMSignal(float power, int frequency);
 
         public Task StopGenerating();
 
         public Task SetGenPort(InstrumentOutputPort outputPort);
 
-        public Task SetRxFrequency(int frequency, string mode);
+        public Task SetRxFrequency(int frequency, testMode mode);
 
         public Task SetTxFrequency(int frequency);
 
@@ -52,7 +58,7 @@
 
         public Task SetupRXTestP25BER();
 
-        public Task GenerateP25STDCal(float power, int frequency);
+        public Task GenerateP25STDCal(float power);
         
     }
 }

--- a/OpenAutoBench-ng/Communication/Instrument/IBaseInstrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IBaseInstrument.cs
@@ -10,13 +10,13 @@
         public Task Connect();
         public Task Disconnect();
         public Task GenerateSignal(float power);
-        public Task GenerateFMSignal(float power, float afFreq);
+        public Task GenerateFMSignal(float power, int frequency);
 
         public Task StopGenerating();
 
         public Task SetGenPort(InstrumentOutputPort outputPort);
 
-        public Task SetRxFrequency(int frequency);
+        public Task SetRxFrequency(int frequency, string mode);
 
         public Task SetTxFrequency(int frequency);
 
@@ -52,7 +52,7 @@
 
         public Task SetupRXTestP25BER();
 
-        public Task GenerateP25STDCal(float power);
+        public Task GenerateP25STDCal(float power, int frequency);
         
     }
 }

--- a/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
@@ -49,12 +49,13 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
             await Send("Generator PTT 1");
         }
 
-        public async Task GenerateFMSignal(float power, float afFreq)
+        public async Task GenerateFMSignal(float power, int frequency)
         {
-            //implementation to review
-            await GenerateSignal(power);
-            await Send("Generator MODulation 1");
+            await Send($"Generator FREQuency {frequency.ToString()} Hz");
+            await Task.Delay(1000);
             await Send($"Generator RFLEVel {power.ToString()}");
+            await Task.Delay(1000);
+            await Send("Generator PTT 1");
         }
             
 
@@ -68,9 +69,16 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
             await Send("Generator RFOUTput 0"); // Set Generator port to T/R
         }
 
-        public async Task SetRxFrequency(int frequency)
+        public async Task SetRxFrequency(int frequency, string mode)
         {
-            await Send($"Receiver FREQuency {frequency.ToString()} Hz");
+            if (mode == "ANALOG" || mode == "P25")
+            {
+                await Send($"Receiver FREQuency {frequency.ToString()} Hz");
+            }
+            else if (mode == "DMR")
+            {
+                throw new NotImplementedException("The IFR2975 does not support DMR.");
+            }
         }
 
         public async Task SetTxFrequency(int frequency)
@@ -211,8 +219,10 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
 
         }
 
-        public async Task GenerateP25STDCal(float power)
+        public async Task GenerateP25STDCal(float power, int frequency)
         {
+            await Send($"Generator FREQuency {frequency.ToString()} Hz");
+            await Task.Delay(1000);
             await Send($"Generator RFLEVel {power.ToString()}"); //Set Generator Power level
             await Task.Delay(1000);
             await Send("Generator PTT 1"); //Send signal

--- a/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/IFR_2975/IFR_2975Instrument.cs
@@ -49,10 +49,8 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
             await Send("Generator PTT 1");
         }
 
-        public async Task GenerateFMSignal(float power, int frequency)
+        public async Task GenerateFMSignal(float power)
         {
-            await Send($"Generator FREQuency {frequency.ToString()} Hz");
-            await Task.Delay(1000);
             await Send($"Generator RFLEVel {power.ToString()}");
             await Task.Delay(1000);
             await Send("Generator PTT 1");
@@ -69,13 +67,13 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
             await Send("Generator RFOUTput 0"); // Set Generator port to T/R
         }
 
-        public async Task SetRxFrequency(int frequency, string mode)
+        public async Task SetRxFrequency(int frequency, testMode mode)
         {
-            if (mode == "ANALOG" || mode == "P25")
+            if (mode == testMode.ANALOG || mode == testMode.P25)
             {
                 await Send($"Receiver FREQuency {frequency.ToString()} Hz");
             }
-            else if (mode == "DMR")
+            else if (mode == testMode.DMR)
             {
                 throw new NotImplementedException("The IFR2975 does not support DMR.");
             }
@@ -219,10 +217,8 @@ namespace OpenAutoBench_ng.Communication.Instrument.IFR_2975
 
         }
 
-        public async Task GenerateP25STDCal(float power, int frequency)
+        public async Task GenerateP25STDCal(float power)
         {
-            await Send($"Generator FREQuency {frequency.ToString()} Hz");
-            await Task.Delay(1000);
             await Send($"Generator RFLEVel {power.ToString()}"); //Set Generator Power level
             await Task.Delay(1000);
             await Send("Generator PTT 1"); //Send signal

--- a/OpenAutoBench-ng/Communication/Instrument/Viavi_8800SX/Viavi_8800SXInstrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Viavi_8800SX/Viavi_8800SXInstrument.cs
@@ -50,9 +50,10 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
             await Send($":gen:lvl:dbm {power}");
         }
 
-        public async Task GenerateFMSignal(float power, float afFreq)
+        public async Task GenerateFMSignal(float power, int frequency)
         {
-            throw new NotImplementedException();
+            await Transmit($":gen:freq {frequency / 1000000D}");
+            await Send($":gen:lvl:dbm {power}");
         }
 
         public async Task StopGenerating()
@@ -65,7 +66,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
             throw new NotImplementedException();
         }
 
-        public async Task SetRxFrequency(int frequency)
+        public async Task SetRxFrequency(int frequency, string mode)
         {
             await Transmit($":rec:freq {frequency / 1000000D}");
         }
@@ -164,7 +165,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
 
         }
 
-        public async Task GenerateP25STDCal(float power)
+        public async Task GenerateP25STDCal(float power, int frequency)
         {
             //Not implemented, but shouldn't raise an exception
         }

--- a/OpenAutoBench-ng/Communication/Instrument/Viavi_8800SX/Viavi_8800SXInstrument.cs
+++ b/OpenAutoBench-ng/Communication/Instrument/Viavi_8800SX/Viavi_8800SXInstrument.cs
@@ -50,9 +50,8 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
             await Send($":gen:lvl:dbm {power}");
         }
 
-        public async Task GenerateFMSignal(float power, int frequency)
+        public async Task GenerateFMSignal(float power)
         {
-            await Transmit($":gen:freq {frequency / 1000000D}");
             await Send($":gen:lvl:dbm {power}");
         }
 
@@ -66,7 +65,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
             throw new NotImplementedException();
         }
 
-        public async Task SetRxFrequency(int frequency, string mode)
+        public async Task SetRxFrequency(int frequency, testMode mode)
         {
             await Transmit($":rec:freq {frequency / 1000000D}");
         }
@@ -165,7 +164,7 @@ namespace OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX
 
         }
 
-        public async Task GenerateP25STDCal(float power, int frequency)
+        public async Task GenerateP25STDCal(float power)
         {
             //Not implemented, but shouldn't raise an exception
         }

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Deviation.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Deviation.cs
@@ -52,7 +52,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.RSSRepeaterBase
                 int TXFrequency = 0;
                 string result = await Repeater.Send($"AL TXDEV GO F{i}");
                 TXFrequency = Convert.ToInt32(result.Split(" = ")[1]);
-                await Instrument.SetRxFrequency(TXFrequency);
+                await Instrument.SetRxFrequency(TXFrequency, "FM");
                 
                 //Repeater.Keyup();     // sending GO will key the repeater up
                 await Task.Delay(5000);

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Deviation.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Deviation.cs
@@ -52,7 +52,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.RSSRepeaterBase
                 int TXFrequency = 0;
                 string result = await Repeater.Send($"AL TXDEV GO F{i}");
                 TXFrequency = Convert.ToInt32(result.Split(" = ")[1]);
-                await Instrument.SetRxFrequency(TXFrequency, "FM");
+                await Instrument.SetRxFrequency(TXFrequency, testMode.ANALOG);
                 
                 //Repeater.Keyup();     // sending GO will key the repeater up
                 await Task.Delay(5000);

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Power.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Power.cs
@@ -50,7 +50,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.RSSRepeaterBase
         protected async Task<float> performTestWithReturn()
         {
             await Repeater.Send($"SET TX PWR {PA_PWR}");
-            await Instrument.SetRxFrequency(TXFrequency);
+            await Instrument.SetRxFrequency(TXFrequency, "FM");
             Repeater.Keyup();
             await Task.Delay(5000);
             float measPower = await Instrument.MeasurePower();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Power.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_Power.cs
@@ -50,7 +50,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.RSSRepeaterBase
         protected async Task<float> performTestWithReturn()
         {
             await Repeater.Send($"SET TX PWR {PA_PWR}");
-            await Instrument.SetRxFrequency(TXFrequency, "FM");
+            await Instrument.SetRxFrequency(TXFrequency, testMode.ANALOG);
             Repeater.Keyup();
             await Task.Delay(5000);
             float measPower = await Instrument.MeasurePower();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_ReferenceOscillator.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_ReferenceOscillator.cs
@@ -59,7 +59,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.RSSRepeaterBase
             float measErr = 0.0f;
             try
             {
-                await Instrument.SetRxFrequency(TXFrequency, "FM");
+                await Instrument.SetRxFrequency(TXFrequency, testMode.ANALOG);
                 Repeater.Keyup();
                 await Task.Delay(5000);
                 measErr = await Instrument.MeasureFrequencyError();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_ReferenceOscillator.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/RSSRepeaterBase/MotorolaRSSRepeater_TestTX_ReferenceOscillator.cs
@@ -59,7 +59,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.RSSRepeaterBase
             float measErr = 0.0f;
             try
             {
-                await Instrument.SetRxFrequency(TXFrequency);
+                await Instrument.SetRxFrequency(TXFrequency, "FM");
                 Repeater.Keyup();
                 await Task.Delay(5000);
                 measErr = await Instrument.MeasureFrequencyError();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_ExtendedFreq.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_ExtendedFreq.cs
@@ -59,8 +59,9 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 {
                     Radio.SetReceiveConfig(XCMPRadioReceiveOption.CSQ);
                     Radio.SetRXFrequency(i, false);
+                    await Instrument.SetTxFrequency(i);
                     await Task.Delay(5000);
-                    await Instrument.GenerateFMSignal(-50, i);
+                    await Instrument.GenerateSignal(-50);
                     await Task.Delay(5000);
                     byte[] rssi = Radio.GetStatus(MotorolaXCMPRadioBase.StatusOperation.RSSI);
                     await Instrument.StopGenerating();
@@ -72,7 +73,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                         Radio.SetReceiveConfig(XCMPRadioReceiveOption.STD_1011);
                         await Instrument.SetupRXTestP25BER();
                         await Task.Delay(5000);
-                        await Instrument.GenerateP25STDCal(-116, i);
+                        await Instrument.GenerateP25STDCal(-116);
                         await Task.Delay(5000);
                         string BER = Radio.GetP25BER(4);
                         await Instrument.StopGenerating();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_ExtendedFreq.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_ExtendedFreq.cs
@@ -59,9 +59,8 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 {
                     Radio.SetReceiveConfig(XCMPRadioReceiveOption.CSQ);
                     Radio.SetRXFrequency(i, false);
-                    await Instrument.SetTxFrequency(i);
                     await Task.Delay(5000);
-                    await Instrument.GenerateSignal(-47);
+                    await Instrument.GenerateFMSignal(-50, i);
                     await Task.Delay(5000);
                     byte[] rssi = Radio.GetStatus(MotorolaXCMPRadioBase.StatusOperation.RSSI);
                     await Instrument.StopGenerating();
@@ -72,14 +71,14 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     {
                         Radio.SetReceiveConfig(XCMPRadioReceiveOption.STD_1011);
                         await Instrument.SetupRXTestP25BER();
-                        await Task.Delay(1000);
-                        await Instrument.GenerateP25STDCal(-116);
+                        await Task.Delay(5000);
+                        await Instrument.GenerateP25STDCal(-116, i);
                         await Task.Delay(5000);
                         string BER = Radio.GetP25BER(4);
                         await Instrument.StopGenerating();
                         LogCallback(String.Format("Measured BER at {0}MHz: {1}", (i / 1000000D), BER));
                         await Instrument.SetupRXTestFMMod();
-                        await Task.Delay(1000);
+                        await Task.Delay(5000);
                     }
                     else
                     {

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_P25BER.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_P25BER.cs
@@ -58,9 +58,8 @@ public class MotorolaXCMPRadio_TestRX_P25BER : IBaseTest
                 int currFreq = TXFrequencies[i];
                 Radio.SetReceiveConfig(XCMPRadioReceiveOption.STD_1011);
                 Radio.SetRXFrequency(currFreq, false);
-                await Instrument.SetTxFrequency(currFreq);
                 await Task.Delay(5000);
-                await Instrument.GenerateP25STDCal(-116); //For future version, this should be a customizable value
+                await Instrument.GenerateP25STDCal(-116, currFreq); //For future version, power should be a customizable value
                 await Task.Delay(5000);
                 string BER = Radio.GetP25BER(4);
                 await Instrument.StopGenerating();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_P25BER.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_P25BER.cs
@@ -58,8 +58,9 @@ public class MotorolaXCMPRadio_TestRX_P25BER : IBaseTest
                 int currFreq = TXFrequencies[i];
                 Radio.SetReceiveConfig(XCMPRadioReceiveOption.STD_1011);
                 Radio.SetRXFrequency(currFreq, false);
+                await Instrument.SetTxFrequency(currFreq);
                 await Task.Delay(5000);
-                await Instrument.GenerateP25STDCal(-116, currFreq); //For future version, power should be a customizable value
+                await Instrument.GenerateP25STDCal(-116); //For future version, this should be a customizable value
                 await Task.Delay(5000);
                 string BER = Radio.GetP25BER(4);
                 await Instrument.StopGenerating();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_RSSI.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_RSSI.cs
@@ -58,7 +58,9 @@ public class MotorolaXCMPRadio_TestRX_RSSI : IBaseTest
                 int currFreq = TXFrequencies[i];
                 Radio.SetReceiveConfig(XCMPRadioReceiveOption.CSQ);
                 Radio.SetRXFrequency(currFreq, false);
-                await Instrument.GenerateFMSignal(-50f, currFreq);
+                await Instrument.SetTxFrequency(currFreq);
+                await Task.Delay(5000);
+                await Instrument.GenerateSignal(-50); //For future version, this should be a customizable value
                 await Task.Delay(5000);
                 byte[] rssi = Radio.GetStatus(MotorolaXCMPRadioBase.StatusOperation.RSSI);
                 await Instrument.StopGenerating();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_RSSI.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestRX_RSSI.cs
@@ -58,9 +58,7 @@ public class MotorolaXCMPRadio_TestRX_RSSI : IBaseTest
                 int currFreq = TXFrequencies[i];
                 Radio.SetReceiveConfig(XCMPRadioReceiveOption.CSQ);
                 Radio.SetRXFrequency(currFreq, false);
-                await Instrument.SetTxFrequency(currFreq);
-                await Task.Delay(5000);
-                await Instrument.GenerateSignal(-47); //For future version, this should be a customizable value
+                await Instrument.GenerateFMSignal(-50f, currFreq);
                 await Task.Delay(5000);
                 byte[] rssi = Radio.GetStatus(MotorolaXCMPRadioBase.StatusOperation.RSSI);
                 await Instrument.StopGenerating();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
@@ -54,10 +54,10 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             try
             {
                 for (int i = 0; i < TXFrequencies.Length; i++)
-                {
+                {   
                     int currFreq = TXFrequencies[i];
                     Radio.SetTXFrequency(currFreq, false);
-                    await Instrument.SetRxFrequency(currFreq);
+                    await Instrument.SetRxFrequency(currFreq, "ANALOG");
                     // low tone
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_LOW);
                     Radio.Keyup();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_DeviationBalance.cs
@@ -57,7 +57,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 {   
                     int currFreq = TXFrequencies[i];
                     Radio.SetTXFrequency(currFreq, false);
-                    await Instrument.SetRxFrequency(currFreq, "ANALOG");
+                    await Instrument.SetRxFrequency(currFreq, testMode.ANALOG);
                     // low tone
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.DEVIATION_LOW);
                     Radio.Keyup();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ExtendedFreq.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ExtendedFreq.cs
@@ -57,7 +57,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 {
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.REFOSC);
                     Radio.SetTXFrequency(i, false);
-                    await Instrument.SetRxFrequency(i, "ANALOG");
+                    await Instrument.SetRxFrequency(i, testMode.ANALOG);
                     Radio.Keyup();
                     await Task.Delay(5000);
                     float measErr = await Instrument.MeasureFrequencyError();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ExtendedFreq.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ExtendedFreq.cs
@@ -57,7 +57,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 {
                     Radio.SetTransmitConfig(XCMPRadioTransmitOption.REFOSC);
                     Radio.SetTXFrequency(i, false);
-                    await Instrument.SetRxFrequency(i);
+                    await Instrument.SetRxFrequency(i, "ANALOG");
                     Radio.Keyup();
                     await Task.Delay(5000);
                     float measErr = await Instrument.MeasureFrequencyError();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_P25_BER.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_P25_BER.cs
@@ -61,7 +61,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     foreach (int TXFrequency in TXFrequencies)
                     {
                         Radio.SetTXFrequency(TXFrequency, true);
-                        await Instrument.SetRxFrequency(TXFrequency);
+                        await Instrument.SetRxFrequency(TXFrequency, "P25");
                         Radio.Keyup();
                         await Task.Delay(1500);
                         await Instrument.ResetBERErrors();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_P25_BER.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_P25_BER.cs
@@ -61,7 +61,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                     foreach (int TXFrequency in TXFrequencies)
                     {
                         Radio.SetTXFrequency(TXFrequency, true);
-                        await Instrument.SetRxFrequency(TXFrequency, "P25");
+                        await Instrument.SetRxFrequency(TXFrequency, testMode.P25);
                         Radio.Keyup();
                         await Task.Delay(1500);
                         await Instrument.ResetBERErrors();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
@@ -60,7 +60,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 for (int i = 0; i < TXFrequencies.Length; i++)
                 {
                     Radio.SetTXFrequency(TXFrequencies[i], false);
-                    await Instrument.SetRxFrequency(TXFrequencies[i]);
+                    await Instrument.SetRxFrequency(TXFrequencies[i], "ANALOG");
 
                     // low power
                     Radio.Keyup();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_PowerCharacterization.cs
@@ -60,7 +60,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
                 for (int i = 0; i < TXFrequencies.Length; i++)
                 {
                     Radio.SetTXFrequency(TXFrequencies[i], false);
-                    await Instrument.SetRxFrequency(TXFrequencies[i], "ANALOG");
+                    await Instrument.SetRxFrequency(TXFrequencies[i], testMode.ANALOG);
 
                     // low power
                     Radio.Keyup();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ReferenceOscillator.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ReferenceOscillator.cs
@@ -55,7 +55,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             try
             {
                 Radio.SetTXFrequency(TXFrequency, false);
-                await Instrument.SetRxFrequency(TXFrequency, "ANALOG");
+                await Instrument.SetRxFrequency(TXFrequency, testMode.ANALOG);
                 Radio.Keyup();
                 await Task.Delay(5000);
                 float measErr = await Instrument.MeasureFrequencyError();

--- a/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ReferenceOscillator.cs
+++ b/OpenAutoBench-ng/Communication/Radio/Motorola/XCMPRadioBase/MotorolaXCMPRadio_TestTX_ReferenceOscillator.cs
@@ -44,7 +44,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             LogCallback(String.Format("Setting up for {0}", name));
             await Instrument.SetDisplay(InstrumentScreen.Monitor);
             await Task.Delay(1000);
-            await Instrument.SetupRefOscillatorTest_P25();
+            await Instrument.SetupRefOscillatorTest_FM();
             await Task.Delay(1000);
 
             // let child set frequency
@@ -55,7 +55,7 @@ namespace OpenAutoBench_ng.Communication.Radio.Motorola.XCMPRadioBase
             try
             {
                 Radio.SetTXFrequency(TXFrequency, false);
-                await Instrument.SetRxFrequency(TXFrequency);
+                await Instrument.SetRxFrequency(TXFrequency, "ANALOG");
                 Radio.Keyup();
                 await Task.Delay(5000);
                 float measErr = await Instrument.MeasureFrequencyError();

--- a/OpenAutoBench-ng/OpenAutoBench/MainLogic.cs
+++ b/OpenAutoBench-ng/OpenAutoBench/MainLogic.cs
@@ -4,6 +4,7 @@ using OpenAutoBench_ng.Communication.Instrument.Connection;
 using OpenAutoBench_ng.Communication.Instrument.HP_8900;
 using OpenAutoBench_ng.Communication.Instrument.IFR_2975;
 using System;
+using System.Text.RegularExpressions;
 using System.IO.Ports;
 using System.ComponentModel;
 using PdfSharpCore.Pdf;
@@ -13,6 +14,7 @@ using PdfSharpCore.Drawing;
 using PdfSharpCore.Drawing.Layout;
 using OpenAutoBench_ng.Communication.Instrument.Astronics_R8000;
 using OpenAutoBench_ng.Communication.Instrument.Viavi_8800SX;
+using OpenAutoBench_ng.Communication.Instrument.GeneralDynamics_R2670;
 
 namespace OpenAutoBench_ng.OpenAutoBench
 {
@@ -81,6 +83,34 @@ namespace OpenAutoBench_ng.OpenAutoBench
                         throw new Exception("Connection to instrument failed: " + e.ToString());
                     }
                     break;
+
+
+                case Settings.InstrumentTypeEnum.R2670:
+                    if (settings.IsGPIB)
+                    {
+                        throw new Exception("GPIB enabled and R2670 selected. GPIB is not supported on this instrument.");
+                    }
+                    int serialPort = 0;
+                    serialPort = int.Parse(Regex.Match(settings.InstrumentSerialPort, @"\d+").Value);
+                    instrument = new GeneralDynamics_R2670Instrument(connection, serialPort);
+                    await instrument.Connect();
+                    await Task.Delay(500);
+
+                    try
+                    {
+                        string instInfo = await instrument.GetInfo();
+                        if (!(instInfo.Length > 0))
+                        {
+                            throw new Exception("Get info succeeded but returned a zero length");
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        await instrument.Disconnect();
+                        throw new Exception("Connection to instrument failed: " + e.ToString());
+                    }
+                    break;
+
 
                 case Settings.InstrumentTypeEnum.IFR_2975:
                     if (settings.IsGPIB)


### PR DESCRIPTION
In order to make this possible, a couple minor tweaks to the way the instruments methods were implemented was necessary. The syntax for the R2670 is not as flexible as other instruments, some actions had to be grouped into one method (frequency and power had to be specified together for example).

The R2670 has limited programmability with P25. The audio settings (to set the P25 patterns) have to be entered via commands emulating key presses as there are no commands to change this setting. The position of the cursor needs to be in it's default location for the test to work. If it is not, it is not fatal, but RX BER tests will report an error.

Also, the R2670 offers no way of recovering the received P25 BER programmatically (for a radio TX test). Because of this, the TX:BER tests will not work for the R2670. In a future version of OAB-ng, we should hide the tests that are not relevant for a given instrument... this is not implemented here as this is out of scope for this commit. 

This was tested on a IFR2975 and R2670A with the P25 Slice and P25 options enabled. 